### PR TITLE
Fix for getting Boomerang packages to show in Helios.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,9 @@ module.exports = function (grunt) {
             all: {
                 src: [
                     'src/Zendo.st', // list all sources in dependency order
-                    'src/Zendo-Tests.st' // list all tests in dependency order
+                    'src/Zendo-Tests.st', // list all tests in dependency order
+                    'src/Boomerang.st', // list all sources in dependency order
+                    'src/Boomerang-Tests.st' // list all sources in dependency order
                 ],
                 amd_namespace: 'zendo',
                 libraries: ['SUnit', 'Web']
@@ -45,6 +47,7 @@ module.exports = function (grunt) {
                     /* add dependencies packages here */
                     'Zendo', /* add other code-to-test packages here */
                     'SUnit',
+                    'Boomerang-Tests', // list all sources in dependency order
                     'Zendo-Tests' /* add other test packages here */
                 ],
                 main_class: 'NodeTestRunner',

--- a/deploy.js
+++ b/deploy.js
@@ -2,7 +2,8 @@ define([
     'amber/deploy',
     // --- packages to be deployed begin here ---
     'amber-contrib-web/Web',
-    'zendo/Zendo'
+    'zendo/Zendo',
+    'zendo/Boomerang'
     // --- packages to be deployed end here ---
 ], function (amber) {
     return amber;

--- a/devel.js
+++ b/devel.js
@@ -3,6 +3,7 @@ define([
     './deploy',
     // --- packages used only during development begin here ---
     'zendo/Zendo-Tests',
+    'zendo/Boomerang-Tests',
     'amber-attic/Benchfib',
     'amber-attic/Examples',
     'amber-attic/IDE'

--- a/src/Boomerang-Tests.js
+++ b/src/Boomerang-Tests.js
@@ -1,8 +1,8 @@
-define("boomerang/Boomerang-Tests", ["amber/boot", "amber_core/SUnit"], function($boot){
+define("zendo/Boomerang-Tests", ["amber/boot", "amber_core/SUnit"], function($boot){
 var $core=$boot.api,nil=$boot.nil,$recv=$boot.asReceiver,$globals=$boot.globals;
 $core.addPackage('Boomerang-Tests');
 $core.packages["Boomerang-Tests"].innerEval = function (expr) { return eval(expr); };
-$core.packages["Boomerang-Tests"].transport = {"type":"amd","amdNamespace":"boomerang"};
+$core.packages["Boomerang-Tests"].transport = {"type":"amd","amdNamespace":"zendo"};
 
 $core.addClass('BoomerangParseWordsAndArraysTest', $globals.TestCase, [], 'Boomerang-Tests');
 $core.addMethod(

--- a/src/Boomerang.js
+++ b/src/Boomerang.js
@@ -1,8 +1,8 @@
-define("boomerang/Boomerang", ["amber/boot", "amber_core/Kernel-Objects", "amber_core/Kernel-Collections"], function($boot){
+define("zendo/Boomerang", ["amber/boot", "amber_core/Kernel-Objects", "amber_core/Kernel-Collections"], function($boot){
 var $core=$boot.api,nil=$boot.nil,$recv=$boot.asReceiver,$globals=$boot.globals;
 $core.addPackage('Boomerang');
 $core.packages["Boomerang"].innerEval = function (expr) { return eval(expr); };
-$core.packages["Boomerang"].transport = {"type":"amd","amdNamespace":"boomerang"};
+$core.packages["Boomerang"].transport = {"type":"amd","amdNamespace":"zendo"};
 
 $core.addClass('Boomerang', $globals.Object, [], 'Boomerang');
 $core.addMethod(


### PR DESCRIPTION
Got them listed in the gruntfile, deploy and devel files.

git clone <repo>
npm install
bower install
grunt devel
# in case one wants to recompile it all

grunt amberc 
amber serve

Works! (Well, shows in Helios)

You way want to do a Boomerang library and then include it, but that's another story.
You'll need a Boomerang.amd.json thing etc.
